### PR TITLE
[Feature] - Add a task to vs code to build, flash and monitor

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,15 +7,14 @@
 			"args": [
 				"test",
 				"--workspace",
-				"--exclude", "focus",
-				"--features", "unit-tests"
+				"--exclude",
+				"focus",
+				"--features",
+				"unit-tests"
 			],
-			"group": {
-				"kind" : "test",
-				"isDefault": true,
-			},
+			"group": "build",
 			"label": "unit-tests",
-			"problemMatcher" : [],
+			"problemMatcher": []
 		},
 		{
 			"type": "shell",
@@ -24,11 +23,11 @@
 				"${cwd}/scripts/build_debug.sh"
 			],
 			"group": {
-				"kind" : "build",
-				"isDefault": false,
+				"kind": "build",
+				"isDefault": false
 			},
 			"label": "Build debug script",
-			"problemMatcher" : [],
+			"problemMatcher": []
 		},
 		{
 			"type": "shell",
@@ -37,11 +36,25 @@
 				"${cwd}/scripts/build_release.sh"
 			],
 			"group": {
-				"kind" : "build",
-				"isDefault": false,
+				"kind": "build",
+				"isDefault": false
 			},
 			"label": "Build release script",
-			"problemMatcher" : [],
+			"problemMatcher": []
 		},
+		{
+			"type": "cargo",
+			"command": "run",
+			"args": [
+				"--target",
+				"xtensa-esp32s3-none-elf"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "Build, Flash, Monitor",
+			"problemMatcher": []
+		}
 	]
 }


### PR DESCRIPTION
# Description

Add a task to vs code to build, flash and monitor based on the cargo run command
This is because `cargo run` does not work since the default target has been removed with #7.
It is therefore a workaround to quickly flash the firmware and launch a monitoring session.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Run the task within VS code and check that it has been correctly executed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


Template from [Embedded Artistry](https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/)